### PR TITLE
Fix wrong color in the player title

### DIFF
--- a/style.css
+++ b/style.css
@@ -5,6 +5,7 @@
   --color-primary-2: #232c50;
   --color-primary-3: #323851;
   --color-primary-4: #242e53;
+  --color-primary-5: #3f4868;
   --color-purple: #8b48bf;
   --color-light-purple: rgba(139, 72, 191, 0.3);
   --color-soft-purple: rgba(139, 72, 191, 0.7);
@@ -359,7 +360,7 @@ header nav a:active {
 }
 
 .player-title {
-  color: var(--color-primary-4);
+  color: var(--color-primary-5);
   font-size: var(--fs-16);
   font-weight: var(--fw-bold);
   line-height: 156.6%;


### PR DESCRIPTION
This PR is to fix a wrong color for the player title in the Best of the month section.

- Desktop view (1440px):

New color: `--color-primary-5: #3f4868;`

![image](https://github.com/MrLapa/responsive-web-design-landing/assets/5798165/918bf43b-f257-41c2-ac2e-a169abef58d7)